### PR TITLE
On Error, body.error check

### DIFF
--- a/lib/v1/gremlin.js
+++ b/lib/v1/gremlin.js
@@ -15,7 +15,7 @@ function Gremlin(client, type) {
       json: true
     }, function(err, res, body) {
       if(err) {
-        callback(body.error ? new Error(body.error) : err);
+        callback((body && body.error) ? new Error(body.error) : err);
       }else {
         callback(null, type == 'shape' ? body : body.result);
       }


### PR DESCRIPTION
prevents things like connection errors (which don't return a body) from
causing another error when `body` is undefined and we check for `body.error`
