### PR TITLE
Fix for API -- data received was always null.

### DIFF
--- a/lib/v1/gremlin.js
+++ b/lib/v1/gremlin.js
@@ -11,9 +11,12 @@ function Gremlin(client, type) {
     var uri = client.host + '/api/' + Gremlin.apiVersion + '/' + type + '/gremlin';
     client.request.post({
       uri: uri,
-      body: text,
-      json: true
+      body: text
     }, function(err, res, body) {
+      try {
+        body = JSON.parse(body);
+      }
+      catch(e) { }
       if(err) {
         callback((body && body.error) ? new Error(body.error) : err);
       }else {


### PR DESCRIPTION
Perhaps this was a change with the request module (I know they made some breaking changes at some point) - but adding `json: true` to the POST was causing `null` to be returned from cayley. Removing `json: true` and manually parsing in the response handler fixed this.